### PR TITLE
Add more items to  file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,6 @@ AllCops:
     - 'public/**/*'
     - 'spec/**/*'
     - 'vendor/**/*'
-    - 'Gemfile'
 
 Metrics/AbcSize:
   Max: 35
@@ -27,4 +26,21 @@ Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
 Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Style/UnneededInterpolation:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: brackets
+
+Style/ConditionalAssignment:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+
+Bundler/OrderedGems:
   Enabled: false


### PR DESCRIPTION
Estou mandando esse PR com algumas coisas que eu adicionei no rubocop, para melhorar nossa análise sobre a qualidade de código, abaixo tem todos os items que eu adicionei, com um link para documentação e um comentãrio explicando o que é esse item e se na minha opinião ele deve ou não fazer parte da análise.

Style/BracesAroundHashParameters:
	Pede {} nas hash com mais de um elemento (sempre bom lembrar, porém isso é algo bem básico)
	Pede pra tirar os {} em hash com um só elemento ex: hash = { total: 10 } deveria ser `has = total: 10` (eu particulamente acho meio confuso sem {})
       [link para documentação](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/BracesAroundHashParameters)

Style/UnneededInterpolation:
	Reclama de interpolação para um elemento string sozinho, ex: bad - `"#{@var_string}"`  good - `@var_string.to_s` (na minha opinião tanto faz, as vezes um é melhor que o outro, mas podemos decidir um padrão) 
**OBS: parece que "#{@var}"	é um pouco mais rápido**
	       [link para documentação](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/UnneededInterpolation)

Naming/AccessorMethodName:
	Reclama de qualquer método que começa com set e get, realmente não é uma boa prática em ruby, mas em alguns casos set e get fazem sentido sim, ainda mais se tratando de uma API que busca informações externas (como um crawler por exemplo)
	       [link para documentação](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AccessorMethodName)

Style/SymbolArray:
  Enabled: true
  EnforcedStyle: brackets
	Reclama da escrita de um array de symbols, # good: `[:foo, :bar, :baz]`
                                                                                       # bad: `%i[foo bar baz]`
	[link para documentação](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/SymbolArray)

Style/ConditionalAssignment:
	Enabled: true
	Reclama da atribuição de uma mesma variável no if e no else, na minha opinião a sugestão do rubocop atrapalha na leitura
	[link para documentação](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/ConditionalAssignment)

Style/NumericPredicate:
	Enabled: false
	Reclama de algumas operções númericas, ex: `if a > 0` deveria ser `if a.positive?`, porém de acordo com uns testes apresentados [nesse link do github](https://github.com/rubocop-hq/rubocop/issues/3633) essa sugestão do rubocop deixa o código mais lento
	[link para documentação](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate)

Tirei o Gemfile dos arquivos ignorados porque o rubocop tem algumas coisas importantes voltadas pro Gemfile, como por exemplo buscar por gems repetidas no arquivo.

Bundler/OrderedGems:
  Enabled: false
  Reclama de gems fora da ordem alfabética (não acho que isso seja um problema, mas podemos deixar em ordem alfabética também)
	