### PR TITLE
Add two more itens to rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,10 @@ Style/ConditionalAssignment:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
 Naming/AccessorMethodName:
   Enabled: false
 

--- a/app/auth/authorize_api_request.rb
+++ b/app/auth/authorize_api_request.rb
@@ -5,7 +5,7 @@ class AuthorizeApiRequest
 
   def call
     {
-      user: user
+      user: user,
     }
   end
 


### PR DESCRIPTION
Atualizando rubocop com mais duas condições

**Sinal de igualdade para tipos e hash**: rubocop reclama do sinal `=== ` e pede pra usar funções no lugar do sinal, porém nem sempre isso é possível e nem sempre faz sentido também.
```
Style/CaseEquality:
  Enabled: false
```
[Texto explicando o ===](http://www.rian.me/2013/10/15/what-is-the-difference-between-equals-equals-equals-and-equals-equals-in-ruby/)
[Link para documentação](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CaseEquality)

---

**self redundante**: rubocop reclama do self redundante dentro das classes, eu não entendi muito bem porque ele reclama disso, até tentei tirar o self onde eu estava usando porém o método não funciona sem ele. E além disso a leitura fica estranha também

```
Style/RedundantSelf:
  Enabled: false
```

[Link para documentação](https://www.rubydoc.info/gems/rubocop/0.16.0/Rubocop/Cop/Style/RedundantSelf)